### PR TITLE
Platform independent line split.

### DIFF
--- a/src/main/java/org/wkh/bateman/trade/GoogleQuoteFetcher.java
+++ b/src/main/java/org/wkh/bateman/trade/GoogleQuoteFetcher.java
@@ -37,7 +37,7 @@ public class GoogleQuoteFetcher implements QuoteFetcher {
     public List<Quote> parseQuotes(String quoteList, int interval) {
         final int dropLines = 6;
         
-        String[] lines = quoteList.split("\n");
+        String[] lines = quoteList.split(System.getProperty("line.separator"));
         
         lines = Arrays.copyOfRange(lines, dropLines, lines.length);
         


### PR DESCRIPTION
Changed GoogleQutoeFetcher.parseQuotes() to use System.getProperty("line.seperator") insetad of \n. Fixes test on Windows.
